### PR TITLE
feat: added hostname setting using svelte stores

### DIFF
--- a/src/api/kenkuApi.ts
+++ b/src/api/kenkuApi.ts
@@ -6,7 +6,8 @@ import type {
 	KenkuSoundboard,
 	KenkuTrack,
 } from "../types";
-const BASE_URL = "http://127.0.0.1:3333/v1";
+import { settings } from "../stores/kenkuStore";
+import { get } from "svelte/store";
 
 export type Result<T> = {
 	data: T | null;
@@ -33,14 +34,20 @@ export interface FetchSoundboardData {
 }
 
 export const fetchPlaylists = (): Promise<Result<FetchPlaylistData>> =>
-	withResult(() => requestUrl(`${BASE_URL}/playlist`).then((res) => res.json));
+	withResult(() =>
+		requestUrl(`${get(settings).hostname}/v1/playlist`).then((res) => res.json),
+	);
 
 export const fetchSoundboards = (): Promise<Result<FetchSoundboardData>> =>
 	withResult(() =>
-		requestUrl(`${BASE_URL}/soundboard`).then((res) => res.json),
+		requestUrl(`${get(settings).hostname}/v1/soundboard`).then(
+			(res) => res.json,
+		),
 	);
 
 export const fetchPlaybackState = (): Promise<Result<KenkuFMState>> =>
 	withResult(() =>
-		requestUrl(`${BASE_URL}/playlist/playback`).then((res) => res.json),
+		requestUrl(`${get(settings).hostname}/v1/playlist/playback`).then(
+			(res) => res.json,
+		),
 	);

--- a/src/kenku/kenku.ts
+++ b/src/kenku/kenku.ts
@@ -6,22 +6,26 @@ import {
 	sounds,
 	soundboards,
 	currentState,
+	settings,
 } from "../stores/kenkuStore";
+import { get } from "svelte/store";
 import type { KenkuItem, KenkuFMState } from "../types";
+import KenkuFMRemotePlugin from "../main";
+import { Plugin } from "obsidian";
 
 export async function initKenkuData() {
 	console.log("[Kenku] Loading Kenku FM Tracks...");
 
 	try {
 		const { tracks: t, playlists: p } = await requestUrl(
-			"http://127.0.0.1:3333/v1/playlist",
+			`${get(settings).hostname}/v1/playlist`,
 		).json;
 		tracks.set(t);
 		playlists.set(p);
 		console.log(`[Kenku] Loaded ${t.length} tracks`);
 
 		const { sounds: s, soundboards: sb } = await requestUrl(
-			"http://127.0.0.1:3333/v1/soundboard",
+			`${get(settings).hostname}/v1/soundboard`,
 		).json;
 		sounds.set(s);
 		soundboards.set(sb);
@@ -33,8 +37,9 @@ export async function initKenkuData() {
 
 export async function getKenkuState(): Promise<KenkuFMState> {
 	try {
-		const state = await requestUrl("http://127.0.0.1:3333/v1/playlist/playback")
-			.json;
+		const state = await requestUrl(
+			`${get(settings).hostname}/v1/playlist/playback`,
+		).json;
 		currentState.set(state);
 		return state as KenkuFMState;
 	} catch (e) {
@@ -46,7 +51,7 @@ export async function getKenkuState(): Promise<KenkuFMState> {
 export async function resumePlayback() {
 	try {
 		await requestUrl({
-			url: "http://127.0.0.1:3333/v1/playlist/playback/play",
+			url: `${get(settings).hostname}/v1/playlist/playback/play`,
 			method: "PUT",
 		});
 	} catch (e) {
@@ -58,7 +63,7 @@ export async function resumePlayback() {
 export async function pausePlayback() {
 	try {
 		await requestUrl({
-			url: "http://127.0.0.1:3333/v1/playlist/playback/pause",
+			url: `${get(settings).hostname}/v1/playlist/playback/pause`,
 			method: "PUT",
 		});
 	} catch (e) {
@@ -80,7 +85,7 @@ export async function playTrack(id: string, restart = false) {
 	}
 
 	await requestUrl({
-		url: "http://127.0.0.1:3333/v1/playlist/play",
+		url: `${get(settings).hostname}/v1/playlist/play`,
 		method: "PUT",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ id }),
@@ -97,7 +102,7 @@ export async function seekTrack(id: string, to: number) {
 	const flooredTo = Math.min(Math.floor(to), track.duration);
 
 	await requestUrl({
-		url: "http://127.0.0.1:3333/v1/playlist/playback/seek",
+		url: `${get(settings).hostname}/v1/playlist/playback/seek`,
 		method: "PUT",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ to: flooredTo }),
@@ -106,7 +111,7 @@ export async function seekTrack(id: string, to: number) {
 
 export async function playSound(id: string) {
 	await requestUrl({
-		url: "http://127.0.0.1:3333/v1/soundboard/play",
+		url: `${get(settings).hostname}/v1/soundboard/play`,
 		method: "PUT",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ id }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,12 +5,16 @@ import { registerCodeBlockProcessors } from "./processors";
 import * as kenkuConnector from "./kenku/kenkuConnector";
 import { isKenkuConnected, settings } from "./stores/kenkuStore";
 import { DEFAULT_SETTINGS } from "./settings/settings";
-import type { ObsidianNoteConnectionsSettings } from "./settings/settings";
 import { KenkuSettingTab } from "./settings/settings";
 
 export default class KenkuFMRemotePlugin extends Plugin {
 	async loadSettings() {
-		settings.set(await this.loadData());
+		const loadedData = await this.loadData();
+		if (loadedData) {
+			settings.set(loadedData);
+		} else {
+			settings.set(DEFAULT_SETTINGS);
+		}
 	}
 
 	async onload() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,25 +3,14 @@ import "virtual:uno.css";
 import { InsertTrackModal } from "./modals";
 import { registerCodeBlockProcessors } from "./processors";
 import * as kenkuConnector from "./kenku/kenkuConnector";
-import { isKenkuConnected } from "./stores/kenkuStore";
-
-interface ObsidianNoteConnectionsSettings {
-	mySetting: string;
-}
-
-const DEFAULT_SETTINGS: ObsidianNoteConnectionsSettings = {
-	mySetting: "default",
-};
+import { isKenkuConnected, settings } from "./stores/kenkuStore";
+import { DEFAULT_SETTINGS } from "./settings/settings";
+import type { ObsidianNoteConnectionsSettings } from "./settings/settings";
+import { KenkuSettingTab } from "./settings/settings";
 
 export default class KenkuFMRemotePlugin extends Plugin {
-	settings!: ObsidianNoteConnectionsSettings;
-
 	async loadSettings() {
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-	}
-
-	async saveSettings() {
-		await this.saveData(this.settings);
+		settings.set(await this.loadData());
 	}
 
 	async onload() {
@@ -36,6 +25,13 @@ export default class KenkuFMRemotePlugin extends Plugin {
 		});
 
 		await kenkuConnector.connect();
+
+		// subscribe to the settings store and save updates
+		settings.subscribe((settings) => {
+			this.saveData(settings);
+		});
+
+		this.addSettingTab(new KenkuSettingTab(this.app, this));
 
 		// this.registerView(VIEW_TYPE_EXAMPLE, (leaf) => new ExampleView(leaf));
 

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -33,11 +33,10 @@ export class KenkuSettingTab extends PluginSettingTab {
 					.setPlaceholder("http://127.0.0.1:3333")
 					.setValue(get(settings).hostname)
 					.onChange(async (value) => {
-						// This is where svelte stores get awkward. The docs claim get() should be avoided. Certainly get() in a context where a set is immediately used?
-						const s = get(settings);
-						s.hostname = value;
-						console.log(`hostname = ${s.hostname}`);
-						settings.set(s);
+						settings.update((s) => {
+							s.hostname = value;
+							return s;
+						});
 					}),
 			);
 	}

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -1,0 +1,44 @@
+import KenkuFMRemotePlugin from "../main";
+import { App, PluginSettingTab, Setting } from "obsidian";
+import { settings } from "../stores/kenkuStore";
+import { get } from "svelte/store";
+
+export interface ObsidianNoteConnectionsSettings {
+	hostname: string;
+}
+
+export const DEFAULT_SETTINGS: ObsidianNoteConnectionsSettings = {
+	hostname: "http://127.0.0.1:3333",
+};
+
+export class KenkuSettingTab extends PluginSettingTab {
+	plugin: KenkuFMRemotePlugin;
+
+	constructor(app: App, plugin: KenkuFMRemotePlugin) {
+		super(app, plugin);
+		this.plugin = plugin;
+	}
+
+	display(): void {
+		const { containerEl } = this;
+
+		containerEl.empty();
+
+		// hostname
+		new Setting(containerEl)
+			.setName("Kenku FM Remote URL")
+			.setDesc("Kenku Remote server protocol, hostname, and port")
+			.addText((text) =>
+				text
+					.setPlaceholder("http://127.0.0.1:3333")
+					.setValue(get(settings).hostname)
+					.onChange(async (value) => {
+						// This is where svelte stores get awkward. The docs claim get() should be avoided. Certainly get() in a context where a set is immediately used?
+						const s = get(settings);
+						s.hostname = value;
+						console.log(`hostname = ${s.hostname}`);
+						settings.set(s);
+					}),
+			);
+	}
+}

--- a/src/stores/kenkuStore.ts
+++ b/src/stores/kenkuStore.ts
@@ -7,7 +7,14 @@ import type {
 	KenkuSound,
 	KenkuSoundboard,
 } from "../types";
+import type { ObsidianNoteConnectionsSettings } from "../settings/settings";
+import { DEFAULT_SETTINGS } from "../settings/settings";
 
+// settings
+export const settings =
+	writable<ObsidianNoteConnectionsSettings>(DEFAULT_SETTINGS);
+
+// sound states
 export const tracks = writable<KenkuTrack[]>([]);
 export const playlists = writable<KenkuPlaylist[]>([]);
 export const sounds = writable<KenkuSound[]>([]);


### PR DESCRIPTION
Not super happy with the warnings about using get() here: https://svelte.dev/docs/svelte/stores
The subscribe() feature is useful in one spot, at least.
Next/future work could include a button in settings to test the endpoint while in the settings, as well as string operations to trim the value of the hostname setting to handle trailing slashes, obvious validity problems, etc.